### PR TITLE
Add code to handle misc window.open calls in the widget

### DIFF
--- a/app/src/main/java/com/example/atriumconnectdemo/ConnectDemo.java
+++ b/app/src/main/java/com/example/atriumconnectdemo/ConnectDemo.java
@@ -9,6 +9,14 @@ import android.webkit.WebView;
 
 public class ConnectDemo extends AppCompatActivity {
     WebView webView;
+    /*
+      In a 'real' application, you would want to get your one time use URL from atrium, then
+      load it into the webview. For demo purposes, we simply hardcode it here.
+
+      See the documentation for more details.
+      https://atrium.mx.com/docs#get-a-url
+     */
+    String widgetURL = "widget url here";
 
     @SuppressLint("SetJavaScriptEnabled")
     @Override
@@ -17,7 +25,7 @@ public class ConnectDemo extends AppCompatActivity {
         setContentView(R.layout.activity_connect_demo);
 
         // set up the webview client for url overrides and settings.
-        MXWebViewClient mxWebViewClient = new MXWebViewClient(this);
+        MXWebViewClient mxWebViewClient = new MXWebViewClient(this, widgetURL);
         WebView webView = (WebView) findViewById(R.id.connectWebView);
         WebSettings settings = webView.getSettings();
 
@@ -25,13 +33,6 @@ public class ConnectDemo extends AppCompatActivity {
         settings.setJavaScriptEnabled(true);
 
 
-        /*
-          In a 'real' application, you would want to get your one time use URL from atrium, then
-          load it into the webview. For demo purposes, we simply hardcode it here.
-
-          See the documentation for more details.
-          https://atrium.mx.com/docs#get-a-url
-         */
-        webView.loadUrl("Connect url goes here.");
+        webView.loadUrl(widgetURL);
     }
 }

--- a/app/src/main/java/com/example/atriumconnectdemo/MXWebViewClient.java
+++ b/app/src/main/java/com/example/atriumconnectdemo/MXWebViewClient.java
@@ -3,6 +3,9 @@ package com.example.atriumconnectdemo;
 import android.app.Activity;
 import android.content.Intent;
 import android.util.Log;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.net.Uri;
@@ -13,9 +16,33 @@ import org.json.JSONObject;
 
 public class MXWebViewClient extends WebViewClient {
     private Activity activity;
+    protected String widgetURL;
 
-    public MXWebViewClient(Activity mainActivity) {
+    public MXWebViewClient(Activity mainActivity, String widgetURL) {
         activity = mainActivity;
+        widgetURL = widgetURL;
+    }
+
+    @Override
+    public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
+        handler.proceed(); // Ignore SSL certificate errors
+    }
+
+    @Override
+    public void onReceivedError (WebView view,
+                                 WebResourceRequest request,
+                                 WebResourceError error) {
+        Log.d("onRecevedError: Request", String.valueOf(request.getUrl()));
+        Log.d("onRecevedError: Error", error.getDescription().toString());
+    }
+
+    @Override
+    public void onReceivedHttpError (WebView view,
+                                     WebResourceRequest request,
+                                     WebResourceResponse errorResponse) {
+        Log.d("HTTP ERROR: response", errorResponse.getReasonPhrase());
+        Log.d("HTTP ERROR: response status", String.valueOf(errorResponse.getStatusCode()));
+        Log.d("onReceivedHTTPError: request", String.valueOf((request.getUrl().toString())));
     }
 
     /**
@@ -53,6 +80,17 @@ public class MXWebViewClient extends WebViewClient {
             } catch (Exception err) {
                 Log.e("MX:Error with OAuth URL", err.getMessage());
             }
+            return true;
+        }
+
+        /**
+         * Open the URL in a different activity if it isn't a message from MX or the widget URL
+         * being loaded.
+         */
+        if (url != widgetURL) {
+            Uri urlToOpen = Uri.parse(url);
+            Intent intent = new Intent(Intent.ACTION_VIEW, urlToOpen);
+            activity.startActivity(intent);
             return true;
         }
 


### PR DESCRIPTION
sometimes a user will click a button or a link and go to a new tab or
window. This is usually for going to the bank's website or viewing
disclosures.

This handles those kind of requests so the webview isn't over writing
the widget session with the new url, but opening the user agent to the
url.